### PR TITLE
Add skipoverlay cmdline parameter

### DIFF
--- a/init-bottom-overlay
+++ b/init-bottom-overlay
@@ -14,6 +14,13 @@ prereqs)
 esac
 
 . /scripts/functions
+
+if grep -q -E '(^|\s)skipoverlay(\s|$)' /proc/cmdline; then
+	log_begin_msg "Skipping overlay, found 'skipoverlay' in cmdline"
+	log_end_msg
+	exit 0
+fi
+
 log_begin_msg "Starting overlay"
 log_end_msg
 


### PR DESCRIPTION
Add 'skipoverlay' to cmdline.txt to skip overlayfs for root fs.