### PR TITLE
Fix /dev/pts mount when exiting rootwork

### DIFF
--- a/rootwork
+++ b/rootwork
@@ -37,5 +37,6 @@ if mountpoint -q /boot; then
 fi
 
 sudo mount -o remount,ro "${ROOT}"
+sudo mount -t devpts devpts /dev/pts
 
 exit 0


### PR DESCRIPTION
Fix /dev/pts mount when exiting rootwork

https://github.com/chesty/overlayroot/issues/6